### PR TITLE
Fixing unit test on mac

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -21,7 +21,7 @@ jobs:
 
     - name: Install via pip
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip wheel
         python -m pip install numpy pytest pytest-cov
         python -m pip install -e .
 


### PR DESCRIPTION
Adding updated `wheel` module to avoid the use of `wheel` system module