### PR TITLE
Fixing CI for mac build

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -21,7 +21,7 @@ jobs:
 
     - name: Install via pip
       run: |
-        python -m pip install --upgrade pip wheel
+        python -m pip install --upgrade pip wheel setuptools
         python -m pip install numpy pytest pytest-cov
         python -m pip install -e .
 


### PR DESCRIPTION
Add `setuptools` when installing the whole stuff